### PR TITLE
Update mpu6050_i2c.c

### DIFF
--- a/i2c/mpu6050_i2c/mpu6050_i2c.c
+++ b/i2c/mpu6050_i2c/mpu6050_i2c.c
@@ -37,8 +37,16 @@ static int addr = 0x68;
 static void mpu6050_reset() {
     // Two byte reset. First byte register, second byte data
     // There are a load more options to set up the device in different ways that could be added here
-    uint8_t buf[] = {0x6B, 0x00};
-    i2c_write_blocking(i2c_default, addr, buf, 2, false);
+    
+   /* Register: PWR_MGMT_1 (0x6B), Value: 0x80, Action: Reset all internal registers (of MPU6050) to default values */
+   uint8_t res[] = {0x6B, 0x80};
+   i2c_write_blocking(i2c_default, addr, res, 2, false);
+   sleep_ms(200); /* Give the device time to perform the reset */
+
+   /* Register: PWR_MGMT_1 (0x6B), Value: 0x00, Action: Take MPU6050 out of sleep mode (which is the default state after reset) */
+   uint8_t wake[] = {0x6B, 0x00};
+   i2c_write_blocking(i2c_default, addr, wake, 2, false);
+   sleep_ms(200); /* Give the device time to get out of the reset */
 }
 
 static void mpu6050_read_raw(int16_t accel[3], int16_t gyro[3], int16_t *temp) {


### PR DESCRIPTION
The reset process requires to set DEVICE_RESET bit in PWR_MGMT_1 (0x6B) bits to one ===> 0x80. then the we must release the reset bit or the device will remain always in reset mode.

detailed explanation is here: #319